### PR TITLE
Changed required php version to 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=7.0.0",
         "pimcore/installer-plugin": ">=1"
     }
 }


### PR DESCRIPTION
Due to using the Spaceship operator <=> the migrations only work w/ PHP7++.