### PR TITLE
offers install option only when pimcore is not installed

### DIFF
--- a/cli/console.php
+++ b/cli/console.php
@@ -9,12 +9,13 @@ use Symfony\Component\Console\Application;
 use Pimcore\ExtensionManager;
 
 $application = new Application('Pimcore Migrations', '1.2.3');
-if (ExtensionManager::isEnabled('plugin', 'Migrations')) {
-    $application->add(new \Migrations\Console\Command\MigrateCommand());
-    $application->add(new \Migrations\Console\Command\GenerateCommand());
-    $application->add(new \Migrations\Console\Command\VersionCommand());
-    $application->add(new \Migrations\Console\Command\CheckCommand());
-} else {
+
+$conf = Pimcore\Config::getSystemConfig();
+if (!$conf) {
+    /**
+     * Pimcore is not installed, we will allow cli installation of pimcore and
+     * enable this plugin in one go
+     */
     include_once(
         realpath(
             __DIR__ . "/../lib/Migrations/Console/Command/InstallCommand.php"
@@ -22,5 +23,24 @@ if (ExtensionManager::isEnabled('plugin', 'Migrations')) {
     );
 
     $application->add(new \Migrations\Console\Command\InstallCommand());
+} else {
+    if (! ExtensionManager::isEnabled('plugin', 'Migrations')) {
+        /**
+         * Pimcore is installed but the migrations plugin is not installed,
+         * install the plugin to allow use of it
+         */
+        ExtensionManager::enable('plugin', 'Migrations');
+
+        // re-init plugins
+        Pimcore::initPlugins();
+    }
+
+    /**
+     * Plugin is fully available, allow migrations
+     */
+    $application->add(new \Migrations\Console\Command\MigrateCommand());
+    $application->add(new \Migrations\Console\Command\GenerateCommand());
+    $application->add(new \Migrations\Console\Command\VersionCommand());
+    $application->add(new \Migrations\Console\Command\CheckCommand());
 }
 $application->run();


### PR DESCRIPTION
The previous check would check if this plugin was enabled to show the
acutal commands, when not enabled it would only offer to install pimcore
from scratch.

We can actually install the plugin on an existing project. We had to
enable the plugin manually, this is cumbersome and kind of useless.

When the plugin is there and you call the cli script it will enable
itself to allow immediate operation.

Signed-off-by: Ike Devolder <ike.devolder@studioemma.eu>